### PR TITLE
#1 並行処理箇所で Slice がデータ競合を起こしていたため、起こさないように修正

### DIFF
--- a/adapter/output/filestorage/s3.go
+++ b/adapter/output/filestorage/s3.go
@@ -7,6 +7,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"golang.org/x/sync/errgroup"
 	"strings"
+	"sync"
+)
+
+var (
+	mutex = sync.Mutex{}
 )
 
 type OutputFileStorageS3Adapter struct {
@@ -68,7 +73,11 @@ func (o *OutputFileStorageS3Adapter) FetchALBLog(param FetchALBLogParam) ([]stri
 				return err
 			}
 			ll := strings.Split(log, "\n")
+
+			mutex.Lock()
 			res = append(res, ll...)
+			mutex.Unlock()
+
 			return nil
 		})
 	}


### PR DESCRIPTION
Closed #1

# 対応内容

- sync.Mutex の Lock, Unlock を使用し、排他制御をおこなうように修正