### PR TITLE
feat: -version オプションを実装

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+MAKEFILE_DIR := $(dir $(lastword $(MAKEFILE_LIST)))
+GO_ENTRY_POINT := 'adapter/input/cli/main.go'
+# TODO: バージョン情報は外部から読み込む形で実現したい
+GO_LD_FLAG := -ldflags '-X "main.cliVersion=v0.1.0"'
+APP_NAME := 'alblogjson'
+
+build.darwin.arm64: clean
+	@cd $(MAKEFILE_DIR) && \
+	GOOS=darwin GOARCH=arm64 go build -o $(GO_LD_FLAG) $(APP_NAME) $(GO_ENTRY_POINT)
+
+build.darwin.amd64: clean
+	@cd $(MAKEFILE_DIR) && \
+	GOOS=darwin GOARCH=amd64 go build $(GO_LD_FLAG) -o $(APP_NAME) $(GO_ENTRY_POINT)
+
+build.linux.amd64: clean
+	@cd $(MAKEFILE_DIR) && \
+	GOOS=linux GOARCH=amd64 go build $(GO_LD_FLAG) -o $(APP_NAME) $(GO_ENTRY_POINT)
+
+clean:
+	@rm -f $(APP_NAME)

--- a/adapter/input/cli/main.go
+++ b/adapter/input/cli/main.go
@@ -5,11 +5,16 @@ import (
 	"alb-log-json/adapter/output/filestorage"
 	"alb-log-json/port/fetch_alb_log"
 	"context"
+	"flag"
 	"fmt"
 	"github.com/BurntSushi/toml"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"os"
+)
+
+var (
+	cliVersion string
 )
 
 type config struct {
@@ -53,6 +58,15 @@ func run(conf *config) int {
 }
 
 func main() {
+	var version bool
+	flag.BoolVar(&version, "version", false, "show version")
+	flag.Parse()
+
+	if version {
+		fmt.Println(cliVersion)
+		os.Exit(0)
+	}
+
 	conf, err := loadConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: failed load toml config.\nCreate `alblogjson-config.toml`.\n")


### PR DESCRIPTION
# コンテキスト

- ツールの保守性を考慮し、バージョンオプションを実装したい

# 対応内容

- Makefile の追加
- flag パッケージを使用し、バージョン情報を出力するように実装